### PR TITLE
Basic logic for API client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "http://rubygems.org"
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,56 @@
+PATH
+  remote: .
+  specs:
+    cta_aggregator_client (0.0.1)
+      rest-client (= 2.0.1)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    coderay (1.0.9)
+    diff-lcs (1.3)
+    domain_name (0.5.20170404)
+      unf (>= 0.0.5, < 1.0.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    method_source (0.8.2)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    netrc (0.11.0)
+    pry (0.9.12.2)
+      coderay (~> 1.0.5)
+      method_source (~> 0.8)
+      slop (~> 3.4)
+    rest-client (2.0.1)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    slop (3.6.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cta_aggregator_client!
+  pry (= 0.9.12.2)
+  rspec (= 3.5.0)
+
+BUNDLED WITH
+   1.14.6

--- a/README.md
+++ b/README.md
@@ -1,2 +1,140 @@
-# cta-aggregator-client-ruby
-A client for the CTA Aggregator project
+# CTAAggregator Client
+
+This gem provides a simple interface for interacting with the CTAAggregator API.
+
+
+## Getting started
+
+You can add this to your Gemfile with:
+
+gem 'cta_aggregator_client'
+Then run bundle install
+
+Next, you'll need to configure the client.  API calls will fail unless you've set the `base_url` and `api_version`.  
+
+
+```
+# config/intitalizers/cta_aggregator_client.rb
+
+CTAAggregatorClient.configure do |config|
+  config.base_url = 'localhost:3000' # (or staging url or production url
+  config.api_version = 'v1'
+end
+```
+
+You'll probably want to store the `base_url` and `api_version` as environment variables.
+
+
+## Usage
+
+Here are a few examples of how you might use this gem.
+
+### CTAs
+
+ list all CTAs
+```
+CTAAggregatorClient::CTA.list
+```
+
+list upcoming CTAs
+```
+CTAAggregatorClient::CTA.list(upcoming: true)
+```
+    
+Find a CTA
+```
+CTAAggregatorClient::CTA.find("some-uuid")
+```
+
+
+Create a CTA
+Note: you will have to have an API Key and Secret in order to create a CTA
+```
+attributes = {
+  title: 'cool thing',
+  descrition: 'blah, blah, blah',
+  website: 'www.example.com',
+  cta_type: "onsite",
+  free: true,
+  start_time: 1524175800,
+  end_time: 1524186600,
+  location_id: "df4aec9f-2ee9-4f53-8708-d32ad2c3babb",
+  contact_id: "be7ba220-47b4-4450-b863-57b82481f2a9" 
+  call_script_id: "df62fbda-93b3-4f34-8a4c-5bf84564b699"
+}
+
+CTAAggregatorClient::CTA.create(attributes)
+```
+
+### Contacts
+
+ list all Contacts
+```
+CTAAggregatorClient::Contact.list
+```
+
+Find a Contact
+```
+CTAAggregatorClient::Contact.find("some-uuid")
+```
+
+
+Create a Contact
+Note: you will have to have an API Key and Secret in order to create a CTA
+```
+attributes = {
+  name: 'George Washington',
+  email: 'NumeroUno@potus.gov'
+}
+
+CTAAggregatorClient::Contact.create(attributes)
+```
+
+### Locations
+
+list all Locations
+```
+CTAAggregatorClient::Location.list
+```
+
+Find a Location
+```
+CTAAggregatorClient::Location.find("some-uuid")
+```
+
+
+Create a Location
+Note: you will have to have an API Key and Secret in order to create a CTA
+```
+attributes = {
+  addres: '123 Fake Street',
+  zipcode: '12345'
+}
+
+CTAAggregatorClient::Location.create(attributes)
+```
+
+### Call Scripts
+
+list all Call Scripts
+```
+CTAAggregatorClient::CallScript.list
+```
+
+Find a Contact
+```
+CTAAggregatorClient::CallScript.find("some-uuid")
+```
+
+
+Create a Contact
+Note: you will have to have an API Key and Secret in order to create a CTA
+
+```
+attributes = {
+  text: 'Hello World.'
+}
+
+CTAAggregatorClient::CallScript.create(attributes)
+```
+

--- a/cta_aggregator_client.gemspec
+++ b/cta_aggregator_client.gemspec
@@ -1,0 +1,21 @@
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require 'cta_aggregator_client/version'
+
+Gem::Specification.new do |s|
+  s.name        = 'cta_aggregator_client'
+  s.version     = CTAAggregatorClient::VERSION
+  s.date        = '2017-04-18'
+  s.summary     = 'Ruby Client for CTA Aggregator'
+  s.authors     = ['Ben Downey']
+  s.email       = 'ben@buildingblocklabs.com'
+  s.homepage    = 'https://github.com/Ragtagteam/cta-aggregator-client-ruby' 
+  s.license       = 'MIT'
+  s.require_path = 'lib'
+  s.files        = Dir['lib/**/*']
+  s.test_files   = Dir['spec/**/*']
+  s.add_dependency 'rest-client', '2.0.1'
+  s.add_development_dependency 'pry', '0.9.12.2'
+  s.add_development_dependency 'rspec', '3.5.0'
+end

--- a/lib/cta_aggregator_client.rb
+++ b/lib/cta_aggregator_client.rb
@@ -1,0 +1,22 @@
+require 'cta_aggregator_client/configuration'
+require 'cta_aggregator_client/cta'
+require 'cta_aggregator_client/contact'
+require 'cta_aggregator_client/location'
+require 'cta_aggregator_client/call_script'
+require 'cta_aggregator_client/api_client'
+
+module CTAAggregatorClient
+
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
+
+end

--- a/lib/cta_aggregator_client/api_client.rb
+++ b/lib/cta_aggregator_client/api_client.rb
@@ -1,0 +1,71 @@
+require 'rest-client'
+require 'json'
+require 'cta_aggregator_client/response'
+
+module CTAAggregatorClient
+  module APIClient 
+
+    DEFAULT_HEADERS = { content_type: 'application/vnd.api+json',
+                        accept: 'application/vnd.api+json' }.freeze
+    class << self
+
+      def list(resource_name, filters)
+        url = "#{base_url}/#{api_version}/#{resource_name}s"
+        raw_response = RestClient.get(url, {headers: headers, params: {filter:  filters} })
+        translate_response(raw_response)
+      end
+
+      def find(resource_name, uuid)
+        url = "#{base_url}/#{api_version}/#{resource_name}s/#{uuid}"
+        raw_response = RestClient.get(url, headers)
+        translate_response(raw_response)
+      end
+
+      def create(resource_name, attributes)
+        url = "#{base_url}/#{api_version}/#{resource_name}s"
+        payload = {
+          'data': {
+            'type': "#{resource_name}s",
+            'attributes': attributes
+          }
+        }.to_json
+
+        perform_request(:post, url, payload)
+      end
+
+      def add_relationship(resource_name, uuid, related_resource_name, related_resource_uuid)
+        url = "#{base_url}/#{api_version}/#{resource_name}s/#{uuid}/relationships/#{related_resource_name}"
+        payload = {
+          'data': {
+            'type': "#{related_resource_name}s",
+            'id': related_resource_uuid
+          }
+        }.to_json
+
+        perform_request(:put, url, payload)
+      end
+
+      def perform_request(http_method, url, payload)
+        raw_response = RestClient.send(http_method.to_sym, url, payload, headers)
+        translate_response(raw_response)
+      end
+
+      def translate_response(response)
+        Response.new(response.code, response.body, response.headers)
+      end
+
+      def headers
+        DEFAULT_HEADERS
+      end
+
+      def base_url
+        CTAAggregatorClient.configuration.base_url
+      end
+
+      def api_version
+        CTAAggregatorClient.configuration.api_version
+      end
+
+    end
+  end
+end

--- a/lib/cta_aggregator_client/call_script.rb
+++ b/lib/cta_aggregator_client/call_script.rb
@@ -1,0 +1,23 @@
+require 'cta_aggregator_client/api_client'
+
+module CTAAggregatorClient
+  module CallScript 
+    class << self
+
+      def list(filters = {})
+        APIClient.list(:call_script, filters)
+      end
+
+      def find(uuid)
+        APIClient.find(:call_script, uuid)
+      end
+
+      def create(attributes = {})
+        attributes = { 'text': attributes[:text] }
+
+        APIClient.create(:call_script, attributes)
+      end
+
+    end
+  end
+end

--- a/lib/cta_aggregator_client/configuration.rb
+++ b/lib/cta_aggregator_client/configuration.rb
@@ -1,0 +1,12 @@
+module CTAAggregatorClient
+  class Configuration
+
+    attr_accessor :base_url, :api_version
+
+    def initialize
+      @base_url = nil
+      @api_version = nil
+    end
+
+  end
+end

--- a/lib/cta_aggregator_client/contact.rb
+++ b/lib/cta_aggregator_client/contact.rb
@@ -1,0 +1,28 @@
+require 'cta_aggregator_client/api_client'
+
+module CTAAggregatorClient
+  module Contact 
+    class << self
+
+      def list(filters = {})
+        APIClient.list(:contact, filters)
+      end
+
+      def find(uuid)
+        APIClient.find(:contact, uuid)
+      end
+
+      def create(attributes = {})
+        attributes = {
+          'name': attributes[:name],
+          'phone': attributes[:phone],
+          'email': attributes[:email],
+          'website': attributes[:website],
+        }.reject{ |k,v| v.nil? }
+
+        APIClient.create(:contact, attributes)
+      end
+
+    end
+  end
+end

--- a/lib/cta_aggregator_client/cta.rb
+++ b/lib/cta_aggregator_client/cta.rb
@@ -1,0 +1,45 @@
+require 'cta_aggregator_client/api_client'
+
+module CTAAggregatorClient
+  module CTA 
+    class << self
+
+      def list(filters = {})
+        APIClient.list(:cta, filters)
+      end
+
+      def find(uuid)
+        APIClient.find(:cta, uuid)
+      end
+
+      def create(attributes = {})
+        attributes = {
+          'title': attributes[:title],
+          'description': attributes[:description],
+          'website': attributes[:website],
+          'free': attributes[:free],
+          'start-time': attributes[:start_time],
+          'end-time': attributes[:end_time],
+          'cta-type': attributes[:cta_type],
+          'location-id': attributes[:location_id],
+          'contact-id': attributes[:contact_id],
+          'call-script-id': attributes[:call_script_id]
+        }.reject{ |k,v| v.nil? }
+
+        APIClient.create(:cta, attributes)
+      end
+
+      def add_contact(cta_uuid, contact_uuid)
+        APIClient.add_relationship(:cta, cta_uuid, :contact, contact_uuid)
+      end
+
+      def add_location(cta_uuid, location_uuid)
+        APIClient.add_relationship(:cta, cta_uuid, :location, location_uuid)
+      end
+
+      def add_call_script(cta_uuid, call_script_uuid)
+        APIClient.add_relationship(:cta, cta_uuid, :call_script, call_script_uuid)
+      end
+    end
+  end
+end

--- a/lib/cta_aggregator_client/location.rb
+++ b/lib/cta_aggregator_client/location.rb
@@ -1,0 +1,29 @@
+require 'cta_aggregator_client/api_client'
+
+module CTAAggregatorClient
+  module Location 
+    class << self
+
+      def list(filters = {})
+        APIClient.list(:location, filters)
+      end
+
+      def find(uuid)
+        APIClient.find(:location, uuid)
+      end
+
+      def create(attributes = {})
+        attrs = {
+          'address': attributes[:address],
+          'city': attributes[:city],
+          'state': attributes[:state],
+          'zipcode': attributes[:zipcode],
+          'notes': attributes[:notes]
+        }.reject{ |k,v| v.nil? }
+
+        APIClient.create(:location, attrs)
+      end
+
+    end
+  end
+end

--- a/lib/cta_aggregator_client/response.rb
+++ b/lib/cta_aggregator_client/response.rb
@@ -1,0 +1,5 @@
+module CTAAggregatorClient
+  class Response < Struct.new(:code, :body, :headers)
+
+  end
+end

--- a/lib/cta_aggregator_client/version.rb
+++ b/lib/cta_aggregator_client/version.rb
@@ -1,0 +1,3 @@
+module CTAAggregatorClient
+  VERSION = '0.0.1'
+end

--- a/spec/factory.rb
+++ b/spec/factory.rb
@@ -1,0 +1,16 @@
+require 'rspec'
+
+module Factory
+
+  class << self
+
+    def response
+      CTAAggregatorClient::Response.new(
+        code: 200,
+        body: 'hello, world',
+        headers: { content_type: 'application/vnd.api+json' }
+      )
+    end
+
+  end
+end

--- a/spec/helpers/test_helpers.rb
+++ b/spec/helpers/test_helpers.rb
@@ -1,0 +1,12 @@
+module TestHelpers
+
+  # Coerces a class name into pluralized resource name 
+  # e.g. "CTAAggregatorClient::CallScript" to "call-scripts" 
+  def formatted_resource_name(klass, hardcoded_klass_name)
+    resource_name = "#{(hardcoded_klass_name || klass.name.split("::")[1].split(/(?=[A-Z])/).map { |class_name_part| class_name_part.downcase }.join('_'))}s"
+  end
+
+  def api_url
+    "#{CTAAggregatorClient::configuration.base_url}/#{CTAAggregatorClient.configuration.api_version}"
+  end
+end

--- a/spec/helpers/u_helpers.rb
+++ b/spec/helpers/u_helpers.rb
@@ -1,0 +1,7 @@
+module UHelpers
+
+  def base_url
+    "#{CTAAggregatorClient::configuration.base_url}/#{CTAAggregatorClient.configuration.api_version}"
+  end
+
+end

--- a/spec/integration/call_script_spec.rb
+++ b/spec/integration/call_script_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe CTAAggregatorClient::CallScript do
+
+  it_behaves_like "listable resource"
+  it_behaves_like "findable resource"
+  context "creation" do
+    attributes = { 'text': 'lorem ipsum' }
+    expected_attributes = { 'text': attributes[:text] }
+    it_behaves_like "creatable resource", attributes, expected_attributes
+  end
+end

--- a/spec/integration/contact_spec.rb
+++ b/spec/integration/contact_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe CTAAggregatorClient::Contact do
+
+  it_behaves_like "listable resource"
+  it_behaves_like "findable resource"
+  context "creation" do
+    attributes  = { 
+      name: "john doe",
+      email: "foobar@example.com"
+    }
+    expected_attributes = {
+      'name': attributes[:name],
+      'email': attributes[:email]
+    }
+    it_behaves_like "creatable resource", attributes, expected_attributes
+  end
+
+end

--- a/spec/integration/cta_spec.rb
+++ b/spec/integration/cta_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+
+describe CTAAggregatorClient::CTA do
+  let(:cta_uuid) { '123' }
+  let(:response) { Factory.response }
+
+  it_behaves_like "listable resource", :cta
+  it_behaves_like "findable resource", :cta
+
+  context "creation" do
+    attributes = {
+      title: "enim tempor ut in aliquip",
+      description: "Excepteur dolore enim voluptate qui",
+      cta_type: "onsite",
+      free: true,
+      website: "www.foobar.com",
+      start_time: 1524175800,
+      end_time: 1524186600,
+      location_id: '4321'
+    }
+
+    expected_attributes = {
+      'title': attributes[:title],
+      'description': attributes[:description],
+      'website': attributes[:website],
+      'free': attributes[:free],
+      'start-time': attributes[:start_time],
+      'end-time': attributes[:end_time],
+      'cta-type': attributes[:cta_type],
+      'location-id': attributes[:location_id]
+    }
+
+    it_behaves_like "creatable resource", attributes, expected_attributes, :cta
+  end
+
+  it 'add a contact' do
+    contact_uuid = '456'
+    url = "#{api_url}/#{:ctas}/#{cta_uuid}/relationships/contact"
+    payload = {
+      'data': {
+        'type': 'contacts',
+        'id': contact_uuid
+      }
+    }
+
+    expect(RestClient).to receive(:put).with(
+      url,
+      payload.to_json,
+      CTAAggregatorClient::APIClient::DEFAULT_HEADERS
+    ).and_return(response)
+
+    expect(described_class.add_contact(cta_uuid, contact_uuid)).to eq response
+  end
+
+  it 'add location' do
+    location_uuid = '456'
+    url = "#{api_url}/#{:ctas}/#{cta_uuid}/relationships/location"
+    payload = {
+      'data': {
+        'type': 'locations',
+        'id': location_uuid
+      }
+    }
+
+    expect(RestClient).to receive(:put).with(
+      url,
+      payload.to_json,
+      CTAAggregatorClient::APIClient::DEFAULT_HEADERS
+    ).and_return(response)
+
+    expect(described_class.add_location(cta_uuid, location_uuid)).to eq response
+  end
+
+  it 'add call script' do
+    call_script_uuid = '789'
+    url = "#{api_url}/#{:ctas}/#{cta_uuid}/relationships/call_script"
+    payload = {
+      'data': {
+        'type': 'call_scripts',
+        'id': call_script_uuid
+      }
+    }
+
+    expect(RestClient).to receive(:put).with(
+      url,
+      payload.to_json,
+      CTAAggregatorClient::APIClient::DEFAULT_HEADERS
+    ).and_return(response)
+
+    expect(described_class.add_call_script(cta_uuid, call_script_uuid)).to eq response
+  end
+end

--- a/spec/integration/location_spec.rb
+++ b/spec/integration/location_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe CTAAggregatorClient::Location do
+
+  it_behaves_like "listable resource"
+  it_behaves_like "findable resource"
+  context "creation" do
+    attributes = { address: "123 fake st", zipcode: "66666" }
+    expected_attrs = {
+      'address': attributes[:address],
+      'zipcode': attributes[:zipcode]
+    }
+    it_behaves_like "creatable resource", attributes, expected_attrs
+  end
+
+end

--- a/spec/shared_examples/creatable_resource.rb
+++ b/spec/shared_examples/creatable_resource.rb
@@ -1,0 +1,24 @@
+shared_examples_for "creatable resource" do |passed_attrs, expected_attrs, resource|
+  let(:response) { Factory.response }
+
+  it 'create new record' do
+    resource_name = formatted_resource_name(described_class, resource)
+ 
+    url = "#{api_url}/#{resource_name}"
+    payload = {
+      'data': {
+        'type': resource_name,
+        'attributes': expected_attrs
+      }
+    }
+
+    expect(RestClient).to receive(:post).with(
+      url,
+      payload.to_json,
+      CTAAggregatorClient::APIClient::DEFAULT_HEADERS
+    ).and_return(response)
+
+    expect(described_class.create(passed_attrs)).to eq response
+  end
+
+end

--- a/spec/shared_examples/findable_resource.rb
+++ b/spec/shared_examples/findable_resource.rb
@@ -1,0 +1,15 @@
+shared_examples_for "findable resource" do |resource|
+  let(:response) { Factory.response }
+
+  it 'find record' do
+    uuid = '123'
+
+    url = "#{api_url}/#{formatted_resource_name(described_class, resource)}/#{uuid}"
+    expect(RestClient).to receive(:get).with(
+      url,
+      CTAAggregatorClient::APIClient::DEFAULT_HEADERS
+    ).and_return(response)
+
+    expect(described_class.find(uuid)).to eq response
+  end
+end

--- a/spec/shared_examples/listable_resource.rb
+++ b/spec/shared_examples/listable_resource.rb
@@ -1,0 +1,26 @@
+shared_examples_for "listable resource" do |resource|
+  let(:response) { Factory.response }
+
+  it 'with no filtering criterial' do
+    url = "#{api_url}/#{formatted_resource_name(described_class, resource)}"
+
+    expect(RestClient).to receive(:get).with(
+      url,
+      {headers: CTAAggregatorClient::APIClient::DEFAULT_HEADERS, params: {filter:  {}}}
+    ).and_return(response)
+
+    expect(described_class.list).to eq response
+  end
+
+  it 'with filtering' do
+    url = "#{api_url}/#{formatted_resource_name(described_class, resource)}"
+    filters = {foo: :bar}
+
+    expect(RestClient).to receive(:get).with(
+      url,
+      {headers: CTAAggregatorClient::APIClient::DEFAULT_HEADERS, params: {filter:  filters}}
+    ).and_return(response)
+
+    expect(described_class.list(filters)).to eq response
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,22 @@
+require 'cta_aggregator_client'
+require 'shared_examples/listable_resource'
+require 'shared_examples/findable_resource'
+require 'shared_examples/creatable_resource'
+require 'helpers/test_helpers'
+require 'factory'
+require 'pry'
+
+RSpec.configure do |config|
+  config.before(:all) do
+    CTAAggregatorClient.configure do |config|
+      config.base_url = 'localhost'
+      config.api_version = 'v1'
+    end
+  end
+
+  config.raise_errors_for_deprecations!
+
+  config.order = 'random'
+
+  config.include TestHelpers
+end


### PR DESCRIPTION
This PR lays the groundwork for a gem that Ruby apps can use to easily access the CTAAggregator.

The goal is to provide a library that's easy for other devs to drop in the their Rails, Sinatra, or Padrino app.

We expect the data model for CTAAggregator to change, which will mean changes to this gem, but this first PR establishes the general approach.