### PR TITLE
Feature/api simplification

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cta_aggregator_client (0.2.0)
+    cta_aggregator_client (0.3.0)
       rest-client (= 2.0.1)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -70,13 +70,11 @@ attributes = {
   featured_image_url: 'http://www.example.com/nya/300x300.png',
   action_type: 'email',
   template: 'Eum itaque et nisi dolores assumenda ipsum. Voluptates qui aut nobis veniam maxime qui',
+  targets: ['a2f6f86b-a214-4892-8c06-8caece820fb0', '215ed993-3cd1-4fbc-b8af-7e2082813d06']
 }
+# Note that becuase an Advocacy Campaign can have many relationships, be sure to send an array of targets, even if there's only one
 
-relationships = { targets: ['a2f6f86b-a214-4892-8c06-8caece820fb0', '215ed993-3cd1-4fbc-b8af-7e2082813d06'] }
-# Note that because an Advocacy can have many relationships, be sure to send an array of targets, even if there's only one
-# e.g. relationships = { targets: ['a2f6f86b-a214-4892-8c06-8caece820fb0'] }
-
-CTAAggregatorClient::CTA.create(attributes, relationships)
+CTAAggregatorClient::CTA.create(attributes)
 ```
 
 Update an Advocacy Campaign
@@ -121,12 +119,11 @@ attributes = {
   start_date: '2017-07-08T03:58:25.098Z',
   end_date: '2017-07-13T03:58:25.098Z',
   free: false,
+  location: '215ed993-3cd1-4fbc-b8af-7e2082813d06'
 }
-relationships = { location: '215ed993-3cd1-4fbc-b8af-7e2082813d06' }
-# Note that because an Event only has one location, so be sure your hash has a key of `location`, rather than `locations`
+# Note that becuase an Event only has one location, so be sure your hash has a key of `location`, rather than `locations`
 
-CTAAggregatorClient::Event.create(attributes, relationships)
-```
+CTAAggregatorClient::Event.create(attributes)
 
 Update an Event
 Note: you can only update a resource that you were responsible for creating.

--- a/lib/cta_aggregator_client/advocacy_campaign.rb
+++ b/lib/cta_aggregator_client/advocacy_campaign.rb
@@ -1,15 +1,19 @@
 require 'cta_aggregator_client/cta_resource'
-
 module CTAAggregatorClient
   module AdvocacyCampaign
     extend CTAResource
 
     RESOURCE_NAME = :advocacy_campaign
+    RELATIONSHIPS = :targets
 
     class << self
 
       def resource_name
         RESOURCE_NAME
+      end
+
+      def relationships
+        RELATIONSHIPS
       end
 
     end

--- a/lib/cta_aggregator_client/api/client.rb
+++ b/lib/cta_aggregator_client/api/client.rb
@@ -57,7 +57,7 @@ module CTAAggregatorClient
         end
 
         def relationship_params(relationships)
-          return {} unless relationships
+          return {} unless relationships && relationships.reject { |k,v| v.nil? }.any?
 
           relationships.each_with_object({}) do |(resource_name, uuid_data), obj|
             if uuid_data.is_a? Array

--- a/lib/cta_aggregator_client/cta_resource.rb
+++ b/lib/cta_aggregator_client/cta_resource.rb
@@ -11,8 +11,12 @@ module CTAAggregatorClient
       API::Client.find(resource_name, uuid)
     end
 
-    def create(attributes, relationships = {})
-      API::Client.create(resource_name, attributes, relationships)
+    def create(attributes)
+      if relationships
+        relationship_data = { relationships => attributes.delete(relationships) }
+      end
+
+      API::Client.create(resource_name, attributes, relationship_data)
     end
 
     def update(attributes)
@@ -26,6 +30,10 @@ module CTAAggregatorClient
 
     def resource_name
       raise NotImplementedError
+    end
+
+    def relationships
+      nil
     end
 
   end

--- a/lib/cta_aggregator_client/event.rb
+++ b/lib/cta_aggregator_client/event.rb
@@ -5,11 +5,16 @@ module CTAAggregatorClient
     extend CTAResource
 
     RESOURCE_NAME = :event
+    RELATIONSHIPS = :location
 
     class << self
 
       def resource_name
         RESOURCE_NAME
+      end
+
+      def relationships
+        RELATIONSHIPS
       end
 
     end

--- a/lib/cta_aggregator_client/version.rb
+++ b/lib/cta_aggregator_client/version.rb
@@ -1,3 +1,3 @@
 module CTAAggregatorClient
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end

--- a/spec/integration/advocacy_campaign_spec.rb
+++ b/spec/integration/advocacy_campaign_spec.rb
@@ -16,9 +16,9 @@ describe CTAAggregatorClient::AdvocacyCampaign do
       featured_image_url: 'http://lorempixel.com/300/300',
       action_type: 'email',
       template: 'Eum itaque et nisi dolores assumenda ipsum. Voluptates qui aut nobis veniam maxime qui. Illum saepe eum corporis vero qui soluta aliquam.\nTemporibus reiciendis velit fugiat. Facere laborum quia ea laboriosam necessitatibus quisquam eligendi. Et est dolorem eligendi id aut sint.\nAnimi qui totam voluptatem nesciunt iure et dolorem. Eos ut dolorum et quo illum fuga atque. Facere a ipsa corrupti assumenda provident commodi facilis. Eligendi officia est et.',
+      targets: ['a2f6f86b-a214-4892-8c06-8caece820fb0', '215ed993-3cd1-4fbc-b8af-7e2082813d06']
     }
-    relationship_attrs = { targets: ['a2f6f86b-a214-4892-8c06-8caece820fb0', '215ed993-3cd1-4fbc-b8af-7e2082813d06'] }
 
-    it_behaves_like 'creatable resource', campaign_attrs, relationship_attrs
+    it_behaves_like 'creatable resource', campaign_attrs, :targets
   end
 end

--- a/spec/integration/events_spec.rb
+++ b/spec/integration/events_spec.rb
@@ -17,10 +17,10 @@ describe CTAAggregatorClient::Event do
       start_date: '2017-07-08T03:58:25.098Z',
       end_date: '2017-07-13T03:58:25.098Z',
       free: false,
+      location: '215ed993-3cd1-4fbc-b8af-7e2082813d06'
     }
-    relationship_attrs = { location: '215ed993-3cd1-4fbc-b8af-7e2082813d06' }
 
-    it_behaves_like 'creatable resource', event_attrs, relationship_attrs
+    it_behaves_like 'creatable resource', event_attrs, :location
   end
 
 end


### PR DESCRIPTION
Originally, creating a resource required passing 2 arguments to the `create` action: one listing the main attributes of the resource and a second to specify relations (e.g. the list of targets associated with an Advocacy Campaign).

This PR simplifies the interface so that gem users can simply pass a single argument.

I've only incremented a minor version for this PR.  Even though this constitutes a breaking change for this gem, the CTAA API is still in alpha.  Until we think the API is stabilized, I'm considering changes like his as minor version bumps.